### PR TITLE
feat: add light themes

### DIFF
--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -135,6 +135,17 @@ export const THEMES = [
 			text: '77 77 76',
 			error: '200 40 41'
 		}
+	},
+	{
+		name: 'paper',
+		label: 'Paper',
+		colors: {
+			bg: '250 250 250',
+			main: '30 30 30',
+			sub: '120 120 120',
+			text: '50 50 50',
+			error: '80 80 80'
+		}
 	}
 ] satisfies Theme[];
 


### PR DESCRIPTION
- added tomorrow theme (closes #96) [(reference)](https://github.com/chriskempson/tomorrow-theme/blob/master/vim/colors/Tomorrow.vim)
- added just a basic monochrome light theme called "paper"

<img width="1680" height="963" alt="image" src="https://github.com/user-attachments/assets/19ee557a-c6f5-4709-a54c-26626da92397" />
<img width="1680" height="961" alt="image" src="https://github.com/user-attachments/assets/b2053329-520f-4e28-9493-8ed814103733" />
